### PR TITLE
Change method of parsing the material type from material name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,21 @@
 
 Run before building dependencies from source:
 
-# Ares
+### Ares
 
 ```bash
 source scripts/ares_setup.sh
 ```
 
-# Ubuntu
+### Ubuntu
 
 ```bash
 source scripts/ubuntu_setup.sh
 ```
 
-# Building dependencies 
+## Building dependencies
 
-scripts/install_deps.sh downloads specified releases, builds them and installs them in ~/libs. 
-
+scripts/install_deps.sh downloads specified releases, builds them and installs them in ~/libs.
 
 ```bash
 ./scripts/install_deps.sh
@@ -57,3 +56,21 @@ The output file is saved in the PPM format. To visualize it, you can utilize the
 ```bash
 eog build/out.ppm
 ```
+
+## Using custom .obj and .mtl files
+
+To use custom .obj and .mtl files, specify the paths to these files in the main.cpp file.
+
+Currently, the program only supports the following materials with the corresponding properties:
+
+- lambertian
+  - Ka
+- metal
+  - Ka
+  - Ns
+- dielectric
+  - Ni
+- diffuse_light
+  - Kd
+
+To use these materials, ensure that the material's name in the .mtl file matches with one from the list above.

--- a/src/obj_loader.h
+++ b/src/obj_loader.h
@@ -123,17 +123,19 @@ void obj_loader::load_faces(hitable **d_list) {
                     aiMaterial *material = scene->mMaterials[mesh->mMaterialIndex];      
 
                     m_ai_material m;
-                    aiString name;
-                    material->Get(AI_MATKEY_NAME, name);
+                    aiString ai_string_name;
+                    material->Get(AI_MATKEY_NAME, ai_string_name);
 
-                    if (name == aiString("lambertian")) {
+                    std::string name = ai_string_name.C_Str();
+                    
+                    if (name.find("lambertian") != std::string::npos) {
                         aiColor3D color;
                         material->Get(AI_MATKEY_COLOR_AMBIENT, color);
 
                         m.type = LAMBERTIAN;
                         m.color_ambient = make_float3(color.r, color.g, color.b);
                     } 
-                    else if (name == aiString("metal")) {
+                    else if (name.find("metal") != std::string::npos) {
                         aiColor3D color;
                         material->Get(AI_MATKEY_COLOR_AMBIENT, color);
 
@@ -144,14 +146,14 @@ void obj_loader::load_faces(hitable **d_list) {
                         m.color_ambient = make_float3(color.r, color.g, color.b); 
                         m.shininess = shininess; 
                     } 
-                    else if (name == aiString("dielectric")) {
+                    else if (name.find("dielectric") != std::string::npos) {
                         float index_of_refraction;
                         material->Get(AI_MATKEY_REFRACTI, index_of_refraction); // Represented as Ni in the mtl file
                     
                         m.type = DIELECTRIC;
                         m.index_of_refraction = index_of_refraction;
                     }
-                    else if (name == aiString("diffuse_light")) {
+                    else if (name.find("diffuse_light") != std::string::npos) {
                         aiColor3D color;
                         material->Get(AI_MATKEY_COLOR_DIFFUSE, color); // Represented as Kd in the mtl file
 

--- a/src/obj_loader.h
+++ b/src/obj_loader.h
@@ -128,14 +128,14 @@ void obj_loader::load_faces(hitable **d_list) {
 
                     std::string name = ai_string_name.C_Str();
                     
-                    if (name.find("lambertian") != std::string::npos) {
+                    if (name.rfind("lambertian", 0) != std::string::npos) {
                         aiColor3D color;
                         material->Get(AI_MATKEY_COLOR_AMBIENT, color);
 
                         m.type = LAMBERTIAN;
                         m.color_ambient = make_float3(color.r, color.g, color.b);
                     } 
-                    else if (name.find("metal") != std::string::npos) {
+                    else if (name.rfind("metal", 0) != std::string::npos) {
                         aiColor3D color;
                         material->Get(AI_MATKEY_COLOR_AMBIENT, color);
 
@@ -146,14 +146,14 @@ void obj_loader::load_faces(hitable **d_list) {
                         m.color_ambient = make_float3(color.r, color.g, color.b); 
                         m.shininess = shininess; 
                     } 
-                    else if (name.find("dielectric") != std::string::npos) {
+                    else if (name.rfind("dielectric", 0) != std::string::npos) {
                         float index_of_refraction;
                         material->Get(AI_MATKEY_REFRACTI, index_of_refraction); // Represented as Ni in the mtl file
                     
                         m.type = DIELECTRIC;
                         m.index_of_refraction = index_of_refraction;
                     }
-                    else if (name.find("diffuse_light") != std::string::npos) {
+                    else if (name.rfind("diffuse_light", 0) != std::string::npos) {
                         aiColor3D color;
                         material->Get(AI_MATKEY_COLOR_DIFFUSE, color); // Represented as Kd in the mtl file
 


### PR DESCRIPTION
This PR:
1. Adds supported materials note to the README.md
2. Changes the way how material types were being detected - now we check if the material name starts with pre-defined material name which is available on our side - expected name of material should be, for example, `metal_red`, `metal_yellow`, etc.

Depends on #14 