### PR TITLE
ObjLoader: fallback to `LAMBERTIAN` when material type is not specified

### DIFF
--- a/src/obj_loader.h
+++ b/src/obj_loader.h
@@ -74,6 +74,10 @@ __global__ void assign_triangle(hitable **d_list, int index, material** material
             }
             else if (d_mat->type == DIFFUSE_LIGHT) {
                 materials[material_index] = new diffuse_light(d_mat->color_diffuse);
+            } 
+            else {
+                // Use LAMBERTIAN by default
+                materials[material_index] = new lambertian(d_mat->color_ambient);
             }
         }
 


### PR DESCRIPTION
This PR adds a support for texture definitions which do not comply with our material specification.