### PR TITLE
Force IDR frame when updating Path Tracer resolution

### DIFF
--- a/src/PixelDataEncoder/H264Encoder.cpp
+++ b/src/PixelDataEncoder/H264Encoder.cpp
@@ -45,6 +45,7 @@ void H264Encoder::updateEncoderIfNeeded(const int width, const int height)
     {
         destroyEncoder();
         initEncoder(width, height);
+        first_frame = true;
     }
 }
 


### PR DESCRIPTION
Forcing to stream IDR frame allows to show the content almost immediately. 